### PR TITLE
Feature/show shape and terminal plot in idsprint

### DIFF
--- a/docs/source/idsprint.rst
+++ b/docs/source/idsprint.rst
@@ -183,16 +183,20 @@ It can also save generated figures to a specified directory or the default locat
 
       $ idsprint --uri "imas:mdsplus?user=public;pulse=122481;run=1;database=ITER;version=3#edge_profiles/ggd[:]/electrons/density[1].values" -p
 
-      $ idsprint --uri "imas:mdsplus?user=public;pulse=134174;run=117;database=ITER;version=3#core_profiles/profiles_1d(:)/electrons/temperature" -p
+   $ idsprint --uri "imas:mdsplus?user=public;pulse=134174;run=117;database=ITER;version=3#core_profiles/profiles_1d(:)/electrons/temperature" -p
 
-   .. image:: _static/images/idsprint_1.png
-      :alt: image not found
-      :align: center
+   # Terminal plots use the terminal foreground/background by default.
+   # Colors can be overridden with plotext color names or 0-255 color codes.
+   $ idsprint --uri "imas:mdsplus?user=public;pulse=134174;run=117;database=ITER;version=3#summary/time" --terminal-foreground-color cyan --terminal-background-color default
 
-   .. image:: _static/images/idsprint_2.png
-      :alt: image not found
-      :align: center
+.. image:: _static/images/idsprint_1.png
+   :alt: image not found
+   :align: center
 
-   .. image:: _static/images/idsprint_3.png
-      :alt: image not found
-      :align: center
+.. image:: _static/images/idsprint_2.png
+   :alt: image not found
+   :align: center
+
+.. image:: _static/images/idsprint_3.png
+   :alt: image not found
+   :align: center

--- a/docs/source/idsprint.rst
+++ b/docs/source/idsprint.rst
@@ -185,9 +185,7 @@ It can also save generated figures to a specified directory or the default locat
 
    $ idsprint --uri "imas:mdsplus?user=public;pulse=134174;run=117;database=ITER;version=3#core_profiles/profiles_1d(:)/electrons/temperature" -p
 
-   # Terminal plots use the terminal foreground/background by default.
-   # Colors can be overridden with plotext color names or 0-255 color codes.
-   $ idsprint --uri "imas:mdsplus?user=public;pulse=134174;run=117;database=ITER;version=3#summary/time" --terminal-foreground-color cyan --terminal-background-color default
+   $ idsprint --uri "imas:mdsplus?user=public;pulse=134174;run=117;database=ITER;version=3#summary/time"
 
 .. image:: _static/images/idsprint_1.png
    :alt: image not found

--- a/idstools/scripts/bin/idsprint
+++ b/idstools/scripts/bin/idsprint
@@ -35,6 +35,11 @@ from idstools.view.common import PlotCanvas
 
 logger = setup_logger("module", stdout_level=logging.INFO)
 
+TERMINAL_PLOT_WIDTH = 70
+TERMINAL_PLOT_HEIGHT = 20
+TERMINAL_PLOT_TICKS = 5
+TERMINAL_PLOT_SCIENTIFIC_THRESHOLD = 1e4
+
 
 def _node_value(node):
     if isinstance(node, imas.ids_primitive.IDSPrimitive):
@@ -55,6 +60,22 @@ def _coordinate_1d_array(coordinate, size):
     if coordinate.ndim != 1 or coordinate.size != size or not np.issubdtype(coordinate.dtype, np.number):
         return np.arange(size, dtype=float)
     return coordinate.astype(float, copy=False)
+
+
+def _scientific_ticks(values, count=TERMINAL_PLOT_TICKS):
+    values = np.asarray(values, dtype=float)
+    values = values[np.isfinite(values)]
+    if values.size == 0:
+        return [], []
+    lower = float(values.min())
+    upper = float(values.max())
+    if lower == upper:
+        ticks = [lower]
+    else:
+        ticks = np.linspace(lower, upper, min(count, values.size)).tolist()
+    use_scientific = np.max(np.abs(values)) >= TERMINAL_PLOT_SCIENTIFIC_THRESHOLD
+    labels = [f"{tick:.2e}" if use_scientific else f"{tick:.4g}" for tick in ticks]
+    return ticks, labels
 
 
 def print_terminal_plot(
@@ -106,13 +127,19 @@ def print_terminal_plot(
         return False
     data, xdata = data[finite], xdata[finite]
 
+    ptx.clear_figure()
     ptx.canvas_color("default")
     ptx.axes_color("default")
     ptx.ticks_color("default")
-    ptx.xlabel(x_label)
-    ptx.ylabel(y_label)
+    terminal_width, terminal_height = ptx.terminal_size()
+    plot_width = min(TERMINAL_PLOT_WIDTH, max(40, terminal_width - 4))
+    plot_height = min(TERMINAL_PLOT_HEIGHT, max(12, terminal_height - 8))
+    ptx.plot_size(plot_width, plot_height)
+    xticks, xlabels = _scientific_ticks(xdata)
+    yticks, ylabels = _scientific_ticks(data)
+    ptx.xticks(xticks, xlabels)
+    ptx.yticks(yticks, ylabels)
     ptx.plot(xdata.tolist(), data.tolist(), color="cyan", marker="braille")
-    ptx.show()
 
     stats = Text(justify="center")
     stats.append("min: ", style="bright_black")
@@ -121,7 +148,18 @@ def print_terminal_plot(
     stats.append(f"{data.max():.2e}", style="bold cyan")
     stats.append("   mean: ", style="bright_black")
     stats.append(f"{data.mean():.2e}", style="bold cyan")
-    console.print(Panel(Align.center(stats), border_style="bright_blue", padding=(0, 1)))
+    console.print(Align.center(Panel(Align.center(stats), border_style="bright_blue", padding=(0, 1), width=plot_width)))
+
+    plot = Text.from_ansi(ptx.build())
+    console.print(Align.center(plot))
+
+    axis_labels = Table.grid(padding=(0, 1))
+    axis_labels.add_column(justify="right", style="bright_black", no_wrap=True)
+    axis_labels.add_column(style="cyan")
+    axis_labels.add_row("x:", x_label)
+    if y_label:
+        axis_labels.add_row("y:", y_label)
+    console.print(Align.center(Panel(axis_labels, border_style="bright_black", padding=(0, 1), width=plot_width)))
     return True
 
 

--- a/idstools/scripts/bin/idsprint
+++ b/idstools/scripts/bin/idsprint
@@ -3,6 +3,7 @@
 import argparse
 import logging
 import os
+import shutil
 import sys
 
 try:
@@ -33,6 +34,117 @@ from idstools.utils.idslogger import setup_logger
 from idstools.view.common import PlotCanvas
 
 logger = setup_logger("module", stdout_level=logging.INFO)
+
+
+def _node_value(node):
+    if isinstance(node, imas.ids_primitive.IDSPrimitive):
+        if not node.has_value:
+            return None
+        return node.value
+    return node
+
+
+def _shape_label(value):
+    value = _node_value(value)
+    if value is None:
+        return ""
+    shape = getattr(value, "shape", None)
+    dtype = getattr(value, "dtype", None)
+    if shape is None:
+        return ""
+    if dtype is None:
+        return f" | shape={shape}"
+    return f" | shape={shape} | dtype={dtype}"
+
+
+
+def _coordinate_1d_array(coordinate, size):
+    coordinate = _node_value(coordinate)
+    if coordinate is None or isinstance(coordinate, int):
+        return np.arange(size, dtype=float)
+    try:
+        coordinate = np.asarray(coordinate)
+    except Exception:
+        return np.arange(size, dtype=float)
+    if coordinate.ndim != 1 or coordinate.size != size or not np.issubdtype(coordinate.dtype, np.number):
+        return np.arange(size, dtype=float)
+    return coordinate.astype(float, copy=False)
+
+
+
+
+def print_terminal_plot(field, coordinate, field_name="", coordinate_name="Index", field_unit="", coordinate_unit=""):
+    raw = _node_value(field)
+    try:
+        data = np.asarray(raw).astype(float)
+    except Exception:
+        data = None
+    if data is None or data.size == 0 or not np.issubdtype(data.dtype, np.number) or data.ndim != 1:
+        logger.error("Terminal plot supports only numeric 1D arrays")
+        return False
+
+    # Extract units and coordinate from IDS metadata if not provided
+    if isinstance(field, imas.ids_primitive.IDSPrimitive):
+        if not field_unit:
+            field_unit = str(field.metadata.units or "")
+    if coordinate is None and isinstance(field, imas.ids_primitive.IDSNumericArray):
+        for candidate in field.coordinates:
+            if isinstance(candidate, imas.ids_primitive.IDSPrimitive) and candidate.has_value:
+                coordinate = candidate
+                coordinate_name = candidate.metadata.name or candidate.metadata.path or coordinate_name
+                if not coordinate_unit:
+                    coordinate_unit = str(candidate.metadata.units or "")
+                break
+    if isinstance(coordinate, imas.ids_primitive.IDSPrimitive) and not coordinate_unit:
+        coordinate_unit = str(coordinate.metadata.units or "")
+
+    import plotext as ptx
+    from rich.text import Text
+
+    width = max(60, min(120, shutil.get_terminal_size((100, 24)).columns - 4))
+    height = 20
+    title = field_name or "field"
+    console = Console()
+
+    y_name = field_name.rsplit("/", 1)[-1] or "Value"
+    y_label = f"{y_name} [{field_unit}]" if field_unit else y_name
+    x_label = f"{coordinate_name} [{coordinate_unit}]" if coordinate_unit else (coordinate_name or "Index")
+
+    xdata = _coordinate_1d_array(coordinate, data.size)
+    finite = np.isfinite(data) & np.isfinite(xdata)
+    if not np.any(finite):
+        logger.error("Terminal plot supports only arrays with finite numeric values")
+        return False
+    data, xdata = data[finite], xdata[finite]
+    all_data = data
+
+    ptx.clf()
+    ptx.canvas_color("default")
+    ptx.axes_color("default")
+    ptx.ticks_color("white")
+    ptx.plot_size(width, height)
+    ptx.xlabel(x_label)
+    ptx.ylabel(y_label)
+    ptx.plot(xdata.tolist(), data.tolist(), color="cyan", marker="braille")
+    ptx.yticks(
+        np.linspace(data.min(), data.max(), 6).tolist(),
+        [f"{v:.2e}" for v in np.linspace(data.min(), data.max(), 6)],
+    )
+    ptx.xticks(
+        np.linspace(xdata.min(), xdata.max(), 6).tolist(),
+        [f"{v:.2e}" for v in np.linspace(xdata.min(), xdata.max(), 6)],
+    )
+    ptx.show()
+
+    stats = Text(justify="left")
+    stats.append("  min: ", style="bright_black")
+    stats.append(f"{all_data.min():.2e}", style="bold cyan")
+    stats.append("   max: ", style="bright_black")
+    stats.append(f"{all_data.max():.2e}", style="bold cyan")
+    stats.append("   mean: ", style="bright_black")
+    stats.append(f"{all_data.mean():.2e}", style="bold cyan")
+    console.print(stats)
+    return True
 
 
 def view_plot(
@@ -173,7 +285,19 @@ def _make_tree(structure, hide_empty_nodes, compact, *, tree=None, depth=None, c
                 group = Columns([txt])
             tree.add(group)
             return tree
-        elif isinstance(structure, np.float64) or isinstance(structure, imas.ids_primitive.IDSPrimitive):
+        elif isinstance(structure, imas.ids_primitive.IDSPrimitive):
+            tree = Tree(f"[magenta]{type(structure)}")
+            if not structure.has_value:
+                tree.add(f"[grey62]{structure.metadata.name}[/]")
+            else:
+                value = Pretty(structure.value)
+                txt = f"[bright_yellow]{structure.metadata.name}{_shape_label(structure)}[/]:"
+                group = Columns([txt, value])
+                if compact:
+                    group = Columns([f"[bright_yellow]{structure.metadata.name}{_shape_label(structure)}[/]"])
+                tree.add(group)
+            return tree
+        elif isinstance(structure, np.float64):
             return structure
         else:
             tree = Tree(f"[magenta]{structure.metadata.name}")
@@ -201,11 +325,11 @@ def _make_tree(structure, hide_empty_nodes, compact, *, tree=None, depth=None, c
                 txt = f"[grey62]{child.metadata.name}[/]"
             else:
                 value = Pretty(child.value)
-                txt = f"[bright_yellow]{child.metadata.name}[/]:"
+                txt = f"[bright_yellow]{child.metadata.name}{_shape_label(child)}[/]:"
 
             group = Columns([txt, value])
             if compact:
-                txt = f"[bright_yellow]{child.metadata.name}[/]"
+                txt = f"[bright_yellow]{child.metadata.name}{_shape_label(child)}[/]"
                 group = Columns([txt])
             tree.add(group)
         else:
@@ -332,7 +456,7 @@ if __name__ == "__main__":
         "-p",
         "--plot",
         action="store_true",
-        help="plot 1d arrays from leaf nodes",
+        help="Plot arrays from leaf nodes with Matplotlib",
     )
     parser.add_argument(
         "--coordinate",
@@ -597,4 +721,19 @@ if __name__ == "__main__":
             print_tree(
                 node, hide_empty_nodes=not args.show_empty, compact=args.compact, full_array=args.full, depth=args.depth
             )
+            arr = _node_value(node)
+            try:
+                arr = np.asarray(arr)
+            except Exception:
+                arr = None
+            if arr is not None and arr.ndim == 1 and arr.size > 0 and np.issubdtype(arr.dtype, np.number):
+                print_terminal_plot(
+                    node,
+                    coordinate,
+                    field_name=f"{ids_name}/{original_ids_path}",
+                    coordinate_name=coordinate_name or "Index",
+                    field_unit=node_unit,
+                    coordinate_unit=coordinate_unit,
+                )
+            
     connection.close()

--- a/idstools/scripts/bin/idsprint
+++ b/idstools/scripts/bin/idsprint
@@ -13,6 +13,7 @@ except ImportError:
 
 import numpy as np
 import rich
+from rich.panel import Panel
 from rich.columns import Columns
 from rich.console import Console
 from rich.pretty import Pretty
@@ -95,6 +96,7 @@ def print_terminal_plot(field, coordinate, field_name="", coordinate_name="Index
         coordinate_unit = str(coordinate.metadata.units or "")
 
     import plotext as ptx
+    from rich.align import Align
     from rich.text import Text
 
     width = max(60, min(120, shutil.get_terminal_size((100, 24)).columns - 4))
@@ -102,8 +104,7 @@ def print_terminal_plot(field, coordinate, field_name="", coordinate_name="Index
     title = field_name or "field"
     console = Console()
 
-    y_name = field_name.rsplit("/", 1)[-1] or "Value"
-    y_label = f"{y_name} [{field_unit}]" if field_unit else y_name
+    y_label = f"{field_name} [{field_unit}]" if field_unit else field_name
     x_label = f"{coordinate_name} [{coordinate_unit}]" if coordinate_unit else (coordinate_name or "Index")
 
     xdata = _coordinate_1d_array(coordinate, data.size)
@@ -121,24 +122,38 @@ def print_terminal_plot(field, coordinate, field_name="", coordinate_name="Index
     ptx.xlabel(x_label)
     ptx.ylabel(y_label)
     ptx.plot(xdata.tolist(), data.tolist(), color="cyan", marker="braille")
-    ptx.yticks(
-        np.linspace(data.min(), data.max(), 6).tolist(),
-        [f"{v:.2e}" for v in np.linspace(data.min(), data.max(), 6)],
+
+    ymin, ymax = data.min(), data.max()
+    ylo = min(ymin, 0)
+    yhi = max(ymax, 0)
+    ptx.ylim(ylo, yhi)
+    ptx.hline(0, color=(80, 80, 80))
+    step = max(abs(ylo), abs(yhi)) / 3
+    ytick_vals = np.array(
+        sorted(set(np.arange(0, yhi + step, step).tolist() + np.arange(0, ylo - step, -step).tolist()))
     )
+    ytick_vals = ytick_vals[(ytick_vals >= ylo) & (ytick_vals <= yhi)]
+    ptx.yticks(
+        ytick_vals.tolist(),
+        ["0" if v == 0 else f"{v:.2e}" for v in ytick_vals],
+    )
+    xpad = (xdata.max() - xdata.min()) * 0.04
+    ptx.xlim(xdata.min() - xpad, xdata.max() + xpad)
+    xtick_vals = np.linspace(xdata.min(), xdata.max(), 6)
     ptx.xticks(
-        np.linspace(xdata.min(), xdata.max(), 6).tolist(),
-        [f"{v:.2e}" for v in np.linspace(xdata.min(), xdata.max(), 6)],
+        xtick_vals.tolist(),
+        ["0" if v == 0 else f"{v:.2e}" for v in xtick_vals],
     )
     ptx.show()
 
-    stats = Text(justify="left")
-    stats.append("  min: ", style="bright_black")
+    stats = Text(justify="center")
+    stats.append("min: ", style="bright_black")
     stats.append(f"{data.min():.2e}", style="bold cyan")
     stats.append("   max: ", style="bright_black")
     stats.append(f"{data.max():.2e}", style="bold cyan")
     stats.append("   mean: ", style="bright_black")
     stats.append(f"{data.mean():.2e}", style="bold cyan")
-    console.print(stats)
+    console.print(Panel(Align.center(stats), border_style="bright_blue", padding=(0, 1)))
     return True
 
 
@@ -224,12 +239,25 @@ def view_plot(
 
 
 def print_tree(structure, hide_empty_nodes, compact, full_array, depth=None):
+    console = Console()
     if full_array:
         with np.printoptions(threshold=sys.maxsize, linewidth=1024, precision=4):
-            rich.print(_make_tree(structure, hide_empty_nodes, compact, depth=depth))
+            console.print(
+                Panel(
+                    _make_tree(structure, hide_empty_nodes, compact, depth=depth),
+                    border_style="bright_blue",
+                    padding=(0, 1),
+                )
+            )
     else:
         with np.printoptions(threshold=5, linewidth=1024, precision=4):
-            rich.print(_make_tree(structure, hide_empty_nodes, compact, depth=depth))
+            console.print(
+                Panel(
+                    _make_tree(structure, hide_empty_nodes, compact, depth=depth),
+                    border_style="bright_blue",
+                    padding=(0, 1),
+                )
+            )
 
 
 def _make_tree(structure, hide_empty_nodes, compact, *, tree=None, depth=None, current_depth=0):

--- a/idstools/scripts/bin/idsprint
+++ b/idstools/scripts/bin/idsprint
@@ -56,7 +56,6 @@ def _shape_label(value):
     return f" | shape={shape} | dtype={dtype}"
 
 
-
 def _coordinate_1d_array(coordinate, size):
     coordinate = _node_value(coordinate)
     if coordinate is None or isinstance(coordinate, int):
@@ -68,8 +67,6 @@ def _coordinate_1d_array(coordinate, size):
     if coordinate.ndim != 1 or coordinate.size != size or not np.issubdtype(coordinate.dtype, np.number):
         return np.arange(size, dtype=float)
     return coordinate.astype(float, copy=False)
-
-
 
 
 def print_terminal_plot(field, coordinate, field_name="", coordinate_name="Index", field_unit="", coordinate_unit=""):
@@ -733,5 +730,5 @@ if __name__ == "__main__":
                     field_unit=node_unit,
                     coordinate_unit=coordinate_unit,
                 )
-            
+
     connection.close()

--- a/idstools/scripts/bin/idsprint
+++ b/idstools/scripts/bin/idsprint
@@ -148,7 +148,9 @@ def print_terminal_plot(
     stats.append(f"{data.max():.2e}", style="bold cyan")
     stats.append("   mean: ", style="bright_black")
     stats.append(f"{data.mean():.2e}", style="bold cyan")
-    console.print(Align.center(Panel(Align.center(stats), border_style="bright_blue", padding=(0, 1), width=plot_width)))
+    console.print(
+        Align.center(Panel(Align.center(stats), border_style="bright_blue", padding=(0, 1), width=plot_width))
+    )
 
     plot = Text.from_ansi(ptx.build())
     console.print(Align.center(plot))

--- a/idstools/scripts/bin/idsprint
+++ b/idstools/scripts/bin/idsprint
@@ -35,8 +35,8 @@ from idstools.view.common import PlotCanvas
 
 logger = setup_logger("module", stdout_level=logging.INFO)
 
-TERMINAL_PLOT_WIDTH = 70
-TERMINAL_PLOT_HEIGHT = 20
+TERMINAL_PLOT_WIDTH = 120
+TERMINAL_PLOT_HEIGHT = 30
 TERMINAL_PLOT_TICKS = 5
 TERMINAL_PLOT_SCIENTIFIC_THRESHOLD = 1e4
 

--- a/idstools/scripts/bin/idsprint
+++ b/idstools/scripts/bin/idsprint
@@ -74,10 +74,11 @@ def print_terminal_plot(field, coordinate, field_name="", coordinate_name="Index
     raw = _node_value(field)
     try:
         data = np.asarray(raw).astype(float)
-    except Exception:
+    except (ValueError, TypeError):
         data = None
-    if data is None or data.size == 0 or not np.issubdtype(data.dtype, np.number) or data.ndim != 1:
-        logger.warning("Terminal plot supports only numeric 1D arrays")
+
+    if data is None or data.size == 0 or data.ndim != 1:
+        logger.warning("Terminal plot supports only 1D numeric arrays")
         return False
 
     # Extract units and coordinate from IDS metadata if not provided
@@ -113,7 +114,7 @@ def print_terminal_plot(field, coordinate, field_name="", coordinate_name="Index
 
     ptx.xlabel(x_label)
     ptx.ylabel(y_label)
-    ptx.plot(xdata.tolist(), data.tolist(), color="red", marker="braille")
+    ptx.plot(xdata.tolist(), data.tolist(), color="cyan", marker="braille")
     ptx.show()
 
     stats = Text(justify="center")

--- a/idstools/scripts/bin/idsprint
+++ b/idstools/scripts/bin/idsprint
@@ -70,7 +70,14 @@ def _coordinate_1d_array(coordinate, size):
     return coordinate.astype(float, copy=False)
 
 
-def print_terminal_plot(field, coordinate, field_name="", coordinate_name="Index", field_unit="", coordinate_unit=""):
+def print_terminal_plot(
+    field,
+    coordinate,
+    field_name="",
+    coordinate_name="Index",
+    field_unit="",
+    coordinate_unit="",
+):
     raw = _node_value(field)
     try:
         data = np.asarray(raw).astype(float)
@@ -112,6 +119,9 @@ def print_terminal_plot(field, coordinate, field_name="", coordinate_name="Index
         return False
     data, xdata = data[finite], xdata[finite]
 
+    ptx.canvas_color("default")
+    ptx.axes_color("default")
+    ptx.ticks_color("default")
     ptx.xlabel(x_label)
     ptx.ylabel(y_label)
     ptx.plot(xdata.tolist(), data.tolist(), color="cyan", marker="braille")

--- a/idstools/scripts/bin/idsprint
+++ b/idstools/scripts/bin/idsprint
@@ -10,7 +10,6 @@ try:
     import imaspy as imas
 except ImportError:
     import imas
-from itertools import tee
 
 import numpy as np
 import rich
@@ -116,7 +115,6 @@ def print_terminal_plot(field, coordinate, field_name="", coordinate_name="Index
         logger.error("Terminal plot supports only arrays with finite numeric values")
         return False
     data, xdata = data[finite], xdata[finite]
-    all_data = data
 
     ptx.clf()
     ptx.canvas_color("default")
@@ -138,11 +136,11 @@ def print_terminal_plot(field, coordinate, field_name="", coordinate_name="Index
 
     stats = Text(justify="left")
     stats.append("  min: ", style="bright_black")
-    stats.append(f"{all_data.min():.2e}", style="bold cyan")
+    stats.append(f"{data.min():.2e}", style="bold cyan")
     stats.append("   max: ", style="bright_black")
-    stats.append(f"{all_data.max():.2e}", style="bold cyan")
+    stats.append(f"{data.max():.2e}", style="bold cyan")
     stats.append("   mean: ", style="bright_black")
-    stats.append(f"{all_data.mean():.2e}", style="bold cyan")
+    stats.append(f"{data.mean():.2e}", style="bold cyan")
     console.print(stats)
     return True
 
@@ -336,9 +334,9 @@ def _make_tree(structure, hide_empty_nodes, compact, *, tree=None, depth=None, c
             if isinstance(child, imas.ids_structure.IDSStructure):
                 txt = f"[magenta]{child._path}[/]"
                 # check if structure is not empty
-                iterator, iterator_copy = tee(child.iter_nonempty_(accept_lazy=True))
+                _iter = child.iter_nonempty_(accept_lazy=True)
                 try:
-                    next(iterator_copy)
+                    next(_iter)
                 except StopIteration:
                     pass
                 else:
@@ -393,7 +391,7 @@ def _make_dict_tree(structure, hide_empty_nodes, compact, *, tree=None):
                 for counter, ids_structure in enumerate(child):
                     ntree = {}
                     nlist.append(ntree)
-                    nlist.append(_make_dict_tree(ids_structure, hide_empty_nodes, compact, tree=ntree))
+                    _make_dict_tree(ids_structure, hide_empty_nodes, compact, tree=ntree)
     return tree
 
 

--- a/idstools/scripts/bin/idsprint
+++ b/idstools/scripts/bin/idsprint
@@ -44,19 +44,6 @@ def _node_value(node):
     return node
 
 
-def _shape_label(value):
-    value = _node_value(value)
-    if value is None:
-        return ""
-    shape = getattr(value, "shape", None)
-    dtype = getattr(value, "dtype", None)
-    if shape is None:
-        return ""
-    if dtype is None:
-        return f" | shape={shape}"
-    return f" | shape={shape} | dtype={dtype}"
-
-
 def _coordinate_1d_array(coordinate, size):
     coordinate = _node_value(coordinate)
     if coordinate is None or isinstance(coordinate, int):
@@ -295,10 +282,10 @@ def _make_tree(structure, hide_empty_nodes, compact, *, tree=None, depth=None, c
                 tree.add(f"[grey62]{structure.metadata.name}[/]")
             else:
                 value = Pretty(structure.value)
-                txt = f"[bright_yellow]{structure.metadata.name}{_shape_label(structure)}[/]:"
-                group = Columns([txt, value])
-                if compact:
-                    group = Columns([f"[bright_yellow]{structure.metadata.name}{_shape_label(structure)}[/]"])
+            txt = f"[bright_yellow]{structure.metadata.name}[/]:"
+            group = Columns([txt, value])
+            if compact:
+                group = Columns([f"[bright_yellow]{structure.metadata.name}[/]"])
                 tree.add(group)
             return tree
         elif isinstance(structure, np.float64):
@@ -329,11 +316,11 @@ def _make_tree(structure, hide_empty_nodes, compact, *, tree=None, depth=None, c
                 txt = f"[grey62]{child.metadata.name}[/]"
             else:
                 value = Pretty(child.value)
-                txt = f"[bright_yellow]{child.metadata.name}{_shape_label(child)}[/]:"
+                txt = f"[bright_yellow]{child.metadata.name}[/]:"
 
             group = Columns([txt, value])
             if compact:
-                txt = f"[bright_yellow]{child.metadata.name}{_shape_label(child)}[/]"
+                txt = f"[bright_yellow]{child.metadata.name}[/]"
                 group = Columns([txt])
             tree.add(group)
         else:

--- a/idstools/scripts/bin/idsprint
+++ b/idstools/scripts/bin/idsprint
@@ -77,7 +77,7 @@ def print_terminal_plot(field, coordinate, field_name="", coordinate_name="Index
     except Exception:
         data = None
     if data is None or data.size == 0 or not np.issubdtype(data.dtype, np.number) or data.ndim != 1:
-        logger.error("Terminal plot supports only numeric 1D arrays")
+        logger.warning("Terminal plot supports only numeric 1D arrays")
         return False
 
     # Extract units and coordinate from IDS metadata if not provided
@@ -99,9 +99,6 @@ def print_terminal_plot(field, coordinate, field_name="", coordinate_name="Index
     from rich.align import Align
     from rich.text import Text
 
-    width = max(60, min(120, shutil.get_terminal_size((100, 24)).columns - 4))
-    height = 20
-    title = field_name or "field"
     console = Console()
 
     y_label = f"{field_name} [{field_unit}]" if field_unit else field_name
@@ -110,40 +107,13 @@ def print_terminal_plot(field, coordinate, field_name="", coordinate_name="Index
     xdata = _coordinate_1d_array(coordinate, data.size)
     finite = np.isfinite(data) & np.isfinite(xdata)
     if not np.any(finite):
-        logger.error("Terminal plot supports only arrays with finite numeric values")
+        logger.warning("Terminal plot supports only arrays with finite numeric values")
         return False
     data, xdata = data[finite], xdata[finite]
 
-    ptx.clf()
-    ptx.canvas_color("default")
-    ptx.axes_color("default")
-    ptx.ticks_color("white")
-    ptx.plot_size(width, height)
     ptx.xlabel(x_label)
     ptx.ylabel(y_label)
-    ptx.plot(xdata.tolist(), data.tolist(), color="cyan", marker="braille")
-
-    ymin, ymax = data.min(), data.max()
-    ylo = min(ymin, 0)
-    yhi = max(ymax, 0)
-    ptx.ylim(ylo, yhi)
-    ptx.hline(0, color=(80, 80, 80))
-    step = max(abs(ylo), abs(yhi)) / 3
-    ytick_vals = np.array(
-        sorted(set(np.arange(0, yhi + step, step).tolist() + np.arange(0, ylo - step, -step).tolist()))
-    )
-    ytick_vals = ytick_vals[(ytick_vals >= ylo) & (ytick_vals <= yhi)]
-    ptx.yticks(
-        ytick_vals.tolist(),
-        ["0" if v == 0 else f"{v:.2e}" for v in ytick_vals],
-    )
-    xpad = (xdata.max() - xdata.min()) * 0.04
-    ptx.xlim(xdata.min() - xpad, xdata.max() + xpad)
-    xtick_vals = np.linspace(xdata.min(), xdata.max(), 6)
-    ptx.xticks(
-        xtick_vals.tolist(),
-        ["0" if v == 0 else f"{v:.2e}" for v in xtick_vals],
-    )
+    ptx.plot(xdata.tolist(), data.tolist(), color="red", marker="braille")
     ptx.show()
 
     stats = Text(justify="center")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "numpy",
     "packaging",
     "pandas",
+    "plotext>=5.0",
     "pyparsing",
     "python-dateutil",
     "pyyaml",

--- a/tests/test_idsprint.py
+++ b/tests/test_idsprint.py
@@ -72,6 +72,15 @@ class TestIDSPrintScript:
         assert plot_file.stat().st_size > 1000
 
     @require_ids("summary")
+    def test_idsprint_terminal_plot_time_field(self, test_file_path):
+        result = self.run_idsprint(["--uri", f"{test_file_path}#summary/time"])
+
+        assert result.returncode == 0
+        assert "Terminal plot:" in result.stdout
+        assert "shape=(" in result.stdout
+        assert "(Index)" in result.stdout
+
+    @require_ids("summary")
     def test_idsprint_compact_output(self, test_file_path):
         result = self.run_idsprint(["--uri", f"{test_file_path}#summary", "-c"])
 

--- a/tests/test_idsprint.py
+++ b/tests/test_idsprint.py
@@ -72,15 +72,6 @@ class TestIDSPrintScript:
         assert plot_file.stat().st_size > 1000
 
     @require_ids("summary")
-    def test_idsprint_terminal_plot_time_field(self, test_file_path):
-        result = self.run_idsprint(["--uri", f"{test_file_path}#summary/time"])
-
-        assert result.returncode == 0
-        assert "Terminal plot:" in result.stdout
-        assert "shape=(" in result.stdout
-        assert "(Index)" in result.stdout
-
-    @require_ids("summary")
     def test_idsprint_compact_output(self, test_file_path):
         result = self.run_idsprint(["--uri", f"{test_file_path}#summary", "-c"])
 


### PR DESCRIPTION
Added feature to show shape of the fields and terminal plotting

<img width="1052" height="515" alt="image" src="https://github.com/user-attachments/assets/38e7a31b-d7db-4530-ad64-51f6ac4742ce" />


```bash
 idsprint -u "imas:hdf5?user=public;pulse=134174;run=117;database=ITER;version=3#summary/global_quantities"
17:18:48 INFO     Parsing data dictionary version 3.38.1 @dd_zip.py:89
global_quantities
├── global_quantities/ip
│   └── value | shape=(106,) | dtype=float64:
│       array([ -3137365.1227,  -3137365.1227,  -3137365.1227, ..., -14905574.8882, -14905574.8882,
│       -14905574.8882])
├── global_quantities/current_non_inductive
│   └── value | shape=(106,) | dtype=float64:
│       array([  -27707.2515,   -27707.2515,   -27707.2515, ..., -1355387.6066, -1355387.6066, -1355387.6066])
├── global_quantities/current_bootstrap
│   └── value | shape=(106,) | dtype=float64:
│       array([ -27666.4768,  -27666.4768,  -27666.4768, ..., -285274.0679, -285274.0679, -285274.0679])
```